### PR TITLE
Disable panRecognizer when the current viewController is root

### DIFF
--- a/Classes/SloppySwiper.m
+++ b/Classes/SloppySwiper.m
@@ -110,6 +110,13 @@
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
     self.duringAnimation = NO;
+    
+    if (navigationController.viewControllers.count <= 1) {
+        self.panRecognizer.enabled = NO;
+    }
+    else {
+        self.panRecognizer.enabled = YES;
+    }
 }
 
 @end


### PR DESCRIPTION
When the current view controller is root, there is no need to pop it.
Also, there are cases that swipe gestures are used to open up side views on root like notifications list.
So I think it is reasonable to disable panRecognizer on SloppySwiper when the current view controller is root.

Anyway, thanks for your great library!
