### PR TITLE
Fix locking when swiping on root view controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SloppySwiper CHANGELOG
 
+## 0.4.1
+
+Fixes a weird "locking" of the whole view when swiping on the right of the root view controller. This especially happend if this view contained a (subclass of) UIScrollView.
+
 ## 0.4.0
 
 Fixes incorrect animation when hidesBottomBarWhenPushed is used.

--- a/Classes/SloppySwiper.m
+++ b/Classes/SloppySwiper.m
@@ -8,7 +8,7 @@
 #import "SSWAnimator.h"
 #import "SSWDirectionalPanGestureRecognizer.h"
 
-@interface SloppySwiper()
+@interface SloppySwiper() <UIGestureRecognizerDelegate>
 @property (weak, readwrite, nonatomic) UIPanGestureRecognizer *panRecognizer;
 @property (weak, nonatomic) IBOutlet UINavigationController *navigationController;
 @property (strong, nonatomic) SSWAnimator *animator;
@@ -50,6 +50,7 @@
     SSWDirectionalPanGestureRecognizer *panRecognizer = [[SSWDirectionalPanGestureRecognizer alloc] initWithTarget:self action:@selector(pan:)];
     panRecognizer.direction = SSWPanDirectionRight;
     panRecognizer.maximumNumberOfTouches = 1;
+    panRecognizer.delegate = self;
     [_navigationController.view addGestureRecognizer:panRecognizer];
     _panRecognizer = panRecognizer;
 
@@ -83,6 +84,15 @@
         }
         self.interactionController = nil;
     }
+}
+
+#pragma mark - UIGestureRecognizerDelegate
+
+-(BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
+    if (self.navigationController.viewControllers.count > 1) {
+        return YES;
+    }
+    return NO;
 }
 
 #pragma mark - UINavigationControllerDelegate

--- a/SloppySwiper.podspec
+++ b/SloppySwiper.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SloppySwiper"
-  s.version          = "0.4.0"
+  s.version          = "0.4.1"
   s.summary          = "UINavigationController delegate that allows swipe back gesture to be started from anywhere on the screen (not just from the edge)."
   s.homepage         = "https://github.com/fastred/SloppySwiper"
   s.license          = 'MIT'


### PR DESCRIPTION
In one of my projects I got reports of users having a view "locking" when they tried to swipe to the right, to see if there is a hamburger menu. 

I was able to successfully reproduce this and is most likely caused by sending touches to both the pan gesture and the underlaying view. Which was is this case a UICollectionView. This caused the animation to start, but never finish. Causing a overlay over the current view, giving the impression of locking the whole app. 