### PR TITLE
Support force touch(3D Touch) device's

### DIFF
--- a/Classes/SSWDirectionalPanGestureRecognizer.m
+++ b/Classes/SSWDirectionalPanGestureRecognizer.m
@@ -22,7 +22,7 @@
     CGPoint velocity = [self velocityInView:self.view];
 
     // check direction only on the first move
-    if (!self.dragging) {
+    if (!self.dragging && !CGPointEqualToPoint(velocity, CGPointZero)) {
         NSDictionary *velocities = @{
                                      @(SSWPanDirectionRight) : @(velocity.x),
                                      @(SSWPanDirectionDown) : @(velocity.y),


### PR DESCRIPTION
Timing `-touchesMoved:withEvent:` is called has been changed on a force touch(3D Touch) supported device's.

---

## Touch the screen. (It does not move the finger)
I have verified the following device's.

### iPhone4s(iOS9.0.0) (Does not support force touch)

	-touchesBegan:withEvent:

### iPhone6s

	-touchesBegan:withEvent:
	-touchesMoved:withEvent:
	
---

`-touchesMoved:withEvent:` is called by the movement to the z-axis direction in force touch(3D Touch) supported device's. Here is changing only the value of [-[UITouch force]](https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UITouch_Class/#//apple_ref/occ/instp/UITouch/force).
Because only [-[UITouch force]](https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UITouch_Class/#//apple_ref/occ/instp/UITouch/force) is changed here, `-velocityInView:` returns CGPointZero.

I added confirmation of CGPointZero to prevent this.