### PR TITLE
[readme] update mit license button color

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SloppySwiper
 
-[![License: MIT](https://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://github.com/fastred/SloppySwiper/blob/master/LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://github.com/fastred/SloppySwiper/blob/master/LICENSE)
 [![CocoaPods](https://img.shields.io/cocoapods/v/SloppySwiper.svg?style=flat)](https://github.com/fastred/SloppySwiper)
 
 `SloppySwiper` is a `UINavigationController` delegate that allows swipe back gesture to be started from anywhere on the screen (not only from the left edge).


### PR DESCRIPTION
Switched the red for blue as red looks like an error.. 😄 