### PR TITLE
Add Sloppy Swiper delegate.

### DIFF
--- a/Classes/SSWAnimator.h
+++ b/Classes/SSWAnimator.h
@@ -4,12 +4,23 @@
 //  Created by Arkadiusz Holko http://holko.pl on 29-05-14.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 // Undocumented animation curve used for the navigation controller's transition.
 FOUNDATION_EXPORT UIViewAnimationOptions const SSWNavigationTransitionCurve;
 
+@class SSWAnimator;
+
+@protocol SSWAnimatorDelegate <NSObject>
+
+@required
+- (BOOL)animatorShouldAnimateTabBar:(SSWAnimator *)animator;
+- (CGFloat)animatorTransitionDimAmount:(SSWAnimator *)animator;
+
+@end
 
 @interface SSWAnimator : NSObject <UIViewControllerAnimatedTransitioning>
+
+@property (nonatomic, weak) id<SSWAnimatorDelegate> delegate;
 
 @end

--- a/Classes/SSWAnimator.m
+++ b/Classes/SSWAnimator.m
@@ -63,7 +63,8 @@ UIViewAnimationOptions const SSWNavigationTransitionCurve = 7 << 16;
 
     // in the default transition the view controller below is a little dimmer than the frontmost one
     UIView *dimmingView = [[UIView alloc] initWithFrame:toViewController.view.bounds];
-    dimmingView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.1f];
+    CGFloat dimAmount = [self.delegate animatorTransitionDimAmount:self];
+    dimmingView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:dimAmount];
     [toViewController.view addSubview:dimmingView];
 
     // fix hidesBottomBarWhenPushed not animated properly
@@ -75,7 +76,8 @@ UIViewAnimationOptions const SSWNavigationTransitionCurve = 7 << 16;
     BOOL tabBarControllerContainsToViewController = [tabBarController.viewControllers containsObject:toViewController];
     BOOL tabBarControllerContainsNavController = [tabBarController.viewControllers containsObject:navController];
     BOOL isToViewControllerFirstInNavController = [navController.viewControllers firstObject] == toViewController;
-    if (tabBar && (tabBarControllerContainsToViewController || (isToViewControllerFirstInNavController && tabBarControllerContainsNavController))) {
+    BOOL shouldAnimateTabBar = [self.delegate animatorShouldAnimateTabBar:self];
+    if (shouldAnimateTabBar && tabBar && (tabBarControllerContainsToViewController || (isToViewControllerFirstInNavController && tabBarControllerContainsNavController))) {
         [tabBar.layer removeAllAnimations];
         
         CGRect tabBarRect = tabBar.frame;

--- a/Classes/SloppySwiper.h
+++ b/Classes/SloppySwiper.h
@@ -4,8 +4,25 @@
 //  Created by Arkadiusz Holko http://holko.pl on 29-05-14.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
+/**
+ * `SloppySwiperDelegate` is a protocol for treaking the behavior of the
+ * `SloppySwiper` object.
+ */
+
+@class SloppySwiper;
+
+@protocol SloppySwiperDelegate <NSObject>
+
+@optional
+// Return NO when you don't want the TabBar to animate during swiping. (Default YES)
+- (BOOL)sloppySwiperShouldAnimateTabBar:(SloppySwiper *)swiper;
+
+// 0.0 means no dimming, 1.0 means pure black. Default is 0.1
+- (CGFloat)sloppySwiperTransitionDimAmount:(SloppySwiper *)swiper;;
+
+@end
 
 /**
  *  `SloppySwiper` is a class conforming to `UINavigationControllerDelegate` protocol that allows pan back gesture to be started from anywhere on the screen (not only from the left edge).
@@ -14,6 +31,8 @@
 
 /// Gesture recognizer used to recognize swiping to the right.
 @property (weak, readonly, nonatomic) UIPanGestureRecognizer *panRecognizer;
+
+@property (nonatomic, weak) id<SloppySwiperDelegate> delegate;
 
 /// Designated initializer if the class isn't used from the Interface Builder.
 - (instancetype)initWithNavigationController:(UINavigationController *)navigationController;

--- a/Classes/SloppySwiper.m
+++ b/Classes/SloppySwiper.m
@@ -8,7 +8,7 @@
 #import "SSWAnimator.h"
 #import "SSWDirectionalPanGestureRecognizer.h"
 
-@interface SloppySwiper() <UIGestureRecognizerDelegate>
+@interface SloppySwiper() <UIGestureRecognizerDelegate, SSWAnimatorDelegate>
 @property (weak, readwrite, nonatomic) UIPanGestureRecognizer *panRecognizer;
 @property (weak, nonatomic) IBOutlet UINavigationController *navigationController;
 @property (strong, nonatomic) SSWAnimator *animator;
@@ -42,6 +42,7 @@
 
 - (void)awakeFromNib
 {
+    [super awakeFromNib];
     [self commonInit];
 }
 
@@ -55,6 +56,25 @@
     _panRecognizer = panRecognizer;
 
     _animator = [[SSWAnimator alloc] init];
+    _animator.delegate = self;
+}
+
+#pragma mark - SSWAnimatorDelegate
+
+- (BOOL)animatorShouldAnimateTabBar:(SSWAnimator *)animator {
+    if ([self.delegate respondsToSelector:@selector(sloppySwiperShouldAnimateTabBar:)]) {
+        return [self.delegate sloppySwiperShouldAnimateTabBar:self];
+    } else {
+        return YES;
+    }
+}
+
+- (CGFloat)animatorTransitionDimAmount:(SSWAnimator *)animator {
+    if ([self.delegate respondsToSelector:@selector(sloppySwiperTransitionDimAmount:)]) {
+        return [self.delegate sloppySwiperTransitionDimAmount:self];
+    } else {
+        return 0.1f;
+    }
 }
 
 #pragma mark - UIPanGestureRecognizer

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
   - the animation tends to be glitchy on the iOS Simulator, but it's fine on the device
   - [`hidesBottomBarWhenPushed` isn't animated properly](https://github.com/fastred/SloppySwiper/issues/2)
 * the gesture can collide with other *pan to the right* gestures
+* If you're having problems with a UINavigationController inside of
+  a UITabBarController that is causing the UITabBar to pop out of view during the animation process,
+  you'll want to implement the SloppySwiperDelegate protocol and return NO for calls to
+  `-(BOOL)sloppySwiperShouldAnimateTabBar:(SloppySwiper *)swiper`.
 
 ![Demo GIF](https://raw.githubusercontent.com/fastred/SloppySwiper/master/demo.gif)
 


### PR DESCRIPTION
This solves a few issues.

1. I was having transition animation problems that caused my view controller to pop in front of the TabBar. I created a delegate protocol for both `SloppySwiper` and `SSWAnimator` that lets the end user set whether or not they want to animate the TabBar when swiping.
2. I also added a delegate method that allows the end-user to set the amount of dimness that occurs during the transition animation.

I created two protocols so that the SSWAnimator class could be hidden from the end user of SloppySwiper.