### PR TITLE
Forward navigation controller delegate methods

### DIFF
--- a/Classes/SloppySwiper.h
+++ b/Classes/SloppySwiper.h
@@ -13,7 +13,7 @@
 
 @class SloppySwiper;
 
-@protocol SloppySwiperDelegate <NSObject>
+@protocol SloppySwiperDelegate <NSObject, UINavigationControllerDelegate>
 
 @optional
 // Return NO when you don't want the TabBar to animate during swiping. (Default YES)

--- a/Classes/SloppySwiper.m
+++ b/Classes/SloppySwiper.m
@@ -117,6 +117,17 @@
 
 #pragma mark - UINavigationControllerDelegate
 
+- (BOOL)respondsToSelector:(SEL)selector {
+    SEL interfaceOrientationsSelector = @selector(navigationControllerSupportedInterfaceOrientations:);
+    SEL interfaceOrientationsForPresentationSelector = @selector(navigationControllerPreferredInterfaceOrientationForPresentation:);
+    
+    // Only use these delegate methods if they can be forwarded
+    if (selector == interfaceOrientationsSelector || selector == interfaceOrientationsForPresentationSelector) {
+        return [self.delegate respondsToSelector:selector];
+    }
+    return [super respondsToSelector:selector];
+}
+
 - (id<UIViewControllerAnimatedTransitioning>)navigationController:(UINavigationController *)navigationController animationControllerForOperation:(UINavigationControllerOperation)operation fromViewController:(UIViewController *)fromVC toViewController:(UIViewController *)toVC
 {
     if (operation == UINavigationControllerOperationPop) {

--- a/Classes/SloppySwiper.m
+++ b/Classes/SloppySwiper.m
@@ -122,6 +122,9 @@
     if (operation == UINavigationControllerOperationPop) {
         return self.animator;
     }
+    if ([self.delegate respondsToSelector:@selector(navigationController:animationControllerForOperation:fromViewController:toViewController:)]) {
+        return [self.delegate navigationController:navigationController animationControllerForOperation:operation fromViewController:fromVC toViewController:toVC];
+    }
     return nil;
 }
 
@@ -135,6 +138,10 @@
     if (animated) {
         self.duringAnimation = YES;
     }
+    
+    if ([self.delegate respondsToSelector:@selector(navigationController:willShowViewController:animated:)]) {
+        [self.delegate navigationController:navigationController willShowViewController:viewController animated:animated];
+    }
 }
 
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
@@ -147,6 +154,24 @@
     else {
         self.panRecognizer.enabled = YES;
     }
+    
+    if ([self.delegate respondsToSelector:@selector(navigationController:didShowViewController:animated:)]) {
+        [self.delegate navigationController:navigationController didShowViewController:viewController animated:animated];
+    }
+}
+
+- (UIInterfaceOrientationMask)navigationControllerSupportedInterfaceOrientations:(UINavigationController *)navigationController {
+    if ([self.delegate respondsToSelector:@selector(navigationControllerSupportedInterfaceOrientations:)]) {
+        return [self.delegate navigationControllerSupportedInterfaceOrientations:navigationController];
+    }
+    return navigationController.supportedInterfaceOrientations;
+}
+
+- (UIInterfaceOrientation)navigationControllerPreferredInterfaceOrientationForPresentation:(UINavigationController *)navigationController {
+    if ([self.delegate respondsToSelector:@selector(navigationControllerPreferredInterfaceOrientationForPresentation:)]) {
+        return [self.delegate navigationControllerPreferredInterfaceOrientationForPresentation:navigationController];
+    }
+    return navigationController.preferredInterfaceOrientationForPresentation;
 }
 
 @end


### PR DESCRIPTION
Allows you to still make use of all `UINavigationControllerDelegate` methods